### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/InterpolatedLogging.Microsoft.Extensions.Logging.Tests/InterpolatedLogging.Microsoft.Extensions.Logging.Tests.csproj
+++ b/src/InterpolatedLogging.Microsoft.Extensions.Logging.Tests/InterpolatedLogging.Microsoft.Extensions.Logging.Tests.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="5.0.0" />
-    <PackageReference Include="Npgsql" Version="4.1.4" />
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@Drizin, I found an issue in the InterpolatedLogging.Microsoft.Extensions.Logging.Tests.csproj:

Packages Npgsql v4.1.4, nunit v3.10.1, NUnit3TestAdapter v3.10.0,Microsoft.NET.Test.Sdk v15.8.0 and System.Data.SqlClient v4.8.1 transitively introduce 101 dependencies into InterpolatedLogging’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/InterpolatedLogging.html)), while Npgsql v4.1.5, nunit v3.11.0, NUnit3TestAdapter v4.0.0, Microsoft.NET.Test.Sdk v15.9.0 and System.Data.SqlClient v4.8.2 can only introduce 60 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/InterpolatedLogging_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose